### PR TITLE
Add .js extensions to imports in ESM build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "nodemon": "^2.0.15",
         "prettier": "^2.5.1",
         "tsm": "^2.2.1",
-        "typescript": "^4.5.2"
+        "typescript": "^4.6.0-dev.20211214"
       },
       "engines": {
         "npm": ">= 7.0.0",
@@ -2686,11 +2686,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "version": "4.6.0-dev.20211214",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.0-dev.20211214.tgz",
+      "integrity": "sha512-ob/0uphXM81aqRfUuMTp4ypwdbfpuJOnmPRvRMyqF11WB3a/2q9gwORi61iRH+rr0skVXgB3mgKc1fsxpSOP9g==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4797,9 +4796,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "version": "4.6.0-dev.20211214",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.0-dev.20211214.tgz",
+      "integrity": "sha512-ob/0uphXM81aqRfUuMTp4ypwdbfpuJOnmPRvRMyqF11WB3a/2q9gwORi61iRH+rr0skVXgB3mgKc1fsxpSOP9g==",
       "dev": true
     },
     "undefsafe": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "nodemon": "^2.0.15",
     "prettier": "^2.5.1",
     "tsm": "^2.2.1",
-    "typescript": "^4.5.2"
+    "typescript": "^4.6.0-dev.20211214"
   },
   "engines": {
     "npm": ">= 7.0.0",

--- a/src/createMockMiddleware.ts
+++ b/src/createMockMiddleware.ts
@@ -8,7 +8,7 @@ import chokidar from 'chokidar';
 import { Key, pathToRegexp } from 'path-to-regexp';
 import signale from 'signale';
 import multer from 'multer';
-import typedObjectKeys from './type-utils/typedObjectKeys';
+import typedObjectKeys from './type-utils/typedObjectKeys.js';
 
 // const VALID_METHODS = ['get', 'post', 'put', 'patch', 'delete', 'head'];
 const BODY_PARSED_METHODS = ['post', 'put', 'patch', 'delete'];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,21 @@
 import fs from 'fs';
-import type { Express, RequestHandler } from 'express'
-import express from 'express'
+import type { Express, RequestHandler } from 'express';
+import express from 'express';
 import { resolve } from 'path';
-import getMockMiddleware from './createMockMiddleware';
+import getMockMiddleware from './createMockMiddleware.js';
 // @ts-ignore
-import type { MockOptions } from './createMockMiddleware';
+import type { MockOptions } from './createMockMiddleware.js';
 
-export type { RequestConfig} from './createMockMiddleware'
+export type { RequestConfig } from './createMockMiddleware.js';
 
 export type ServerOptions = MockOptions & {
-  mountPath?: string,
+  mountPath?: string;
   useUnixSocket?: boolean;
   socketPath?: string;
-  host?: string,
-  port?: number,
-  mockDir?: string,
-}
+  host?: string;
+  port?: number;
+  mockDir?: string;
+};
 
 const DEFAULT_SERVER_OPTIONS: Required<Omit<ServerOptions, 'mockDir' | keyof MockOptions>> = {
   mountPath: '/api/',
@@ -23,17 +23,19 @@ const DEFAULT_SERVER_OPTIONS: Required<Omit<ServerOptions, 'mockDir' | keyof Moc
   port: 9002,
   useUnixSocket: false,
   socketPath: resolve(process.cwd(), './socket'),
-}
+};
 
 export function createServer(serverOptions: ServerOptions = {}): Express {
-  const { mountPath, mockDir, socketPath, useUnixSocket, host, port, ...options } = {...DEFAULT_SERVER_OPTIONS, ...serverOptions};
+  const { mountPath, mockDir, socketPath, useUnixSocket, host, port, ...options } = {
+    ...DEFAULT_SERVER_OPTIONS,
+    ...serverOptions,
+  };
 
   const app = express();
   app.use(mountPath, createMockMiddleWare(mockDir, options));
 
   // return 404 response to unmatched routes under the mount path
   app.use(mountPath, (req, res) => res.sendStatus(404));
-
 
   if (useUnixSocket) {
     // clean up previous socket connection

--- a/tsconfig.build.esm.json
+++ b/tsconfig.build.esm.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "ESNext",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "target": "ES6",
     "outDir": "./dist/esm",
     "declaration": true


### PR DESCRIPTION
- Update TS to 4.6 nightly to support new `nodenext` value for `module`
and `moduleResolution` fields
- Change TS imports to use the `.js` extension